### PR TITLE
plSceneObject SDL flags

### DIFF
--- a/PyPRP/prp_ResManager.py
+++ b/PyPRP/prp_ResManager.py
@@ -904,9 +904,14 @@ class alcUruPage:
             else: # Not recognized here
                 objlist4.append(obj)
 
+        # Fifth pass:
+        #  SceneObject SDL flags
+        so_idx = self.prp.findidx(0x01)
+        for i in so_idx.objs:
+            i.data.checkSynchFlags()
 
 
-                ### End export code
+        ### End export code
         if self.type in (0x04,0x00):
             #update sceneNode
             self.prp.updateSceneNode()


### PR DESCRIPTION
PlasmaMax does a decent job of automating network synchronization flags. It's pretty important that we get these right in our ages in an online environment, otherwise unscrupulous users can break a persistent age pretty seriously and require some admin intervention. This changeset corrects that problem and should make life a bit easier for artists.